### PR TITLE
Async client and backing store

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,12 +12,38 @@ from contextlib import asynccontextmanager
 from auth_fastapi import scoped_get, scoped_head, scoped_put, scoped_delete
 
 
+class AsyncDictStore:
+    """A simple in-memory async object store for demonstration purposes."""
+    def __init__(self):
+        self.store = {}
+
+    async def put(self, key: str, data: bytes) -> None:
+        self.store[key] = data
+
+    async def get(self, key: str) -> bytes:
+        if key not in self.store:
+            raise KeyError(f"Object {key} not found")
+        return self.store[key]
+
+    async def exists(self, key: str) -> bool:
+        return key in self.store
+
+    async def delete(self, key: str) -> None:
+        if key not in self.store:
+            raise KeyError(f"Object {key} not found")
+        del self.store[key]
+
+    async def keys(self):
+        for key in self.store.keys():
+            yield key
+
+
 @asynccontextmanager
 async def lifespan(app):
     # This is where you would initialize your object store
     # Example:
     from storage.object import DictStore
-    app.state.store = DictStore()
+    app.state.store = AsyncDictStore()
     yield
     # This is where you would clean up your object store if needed
 
@@ -75,7 +101,7 @@ async def put_object(
     data = await request.body()
     
     try:
-        store.put(key, data)
+        await store.put(key, data)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -95,7 +121,7 @@ async def get_object(
     store = get_store(request)
     
     try:
-        data = store.get(key)
+        data = await store.get(key)
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Object {key} not found")
     
@@ -114,7 +140,7 @@ async def head_object(
     """Check if an object exists"""
     store = get_store(request)
     
-    if not store.exists(key):
+    if not await store.exists(key):
         raise HTTPException(status_code=404)
     
     return Response(status_code=200)
@@ -129,7 +155,7 @@ async def delete_object(
     store = get_store(request)
     
     try:
-        store.delete(key)
+        await store.delete(key)
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Object {key} not found")
     
@@ -148,7 +174,7 @@ async def list_objects(
     
     try:
         # Get all keys and sort them for consistent pagination
-        all_keys = sorted(store.keys())
+        all_keys = sorted([key async for key in store.keys()])
     except NotImplementedError:
         raise HTTPException(
             status_code=501,

--- a/app.py
+++ b/app.py
@@ -42,7 +42,6 @@ class AsyncDictStore:
 async def lifespan(app):
     # This is where you would initialize your object store
     # Example:
-    from storage.object import DictStore
     app.state.store = AsyncDictStore()
     yield
     # This is where you would clean up your object store if needed

--- a/async_client.py
+++ b/async_client.py
@@ -192,7 +192,7 @@ class AsyncRestStore:
                 raise KeyError(f"Object {key} does not exist")
             await resp.release()
         except AsyncRestStoreError as e:
-            raise KeyError(f"Failed to delete object {key}: {str(e)}")
+            raise AsyncRestStoreError(f"Failed to delete object {key}: {str(e)}")
 
     async def keys(self) -> AsyncIterator[str]:
         """List all object keys with pagination (async iterator)."""

--- a/async_client.py
+++ b/async_client.py
@@ -91,7 +91,7 @@ class AsyncRestStore:
         instead of being turned into AsyncRestStoreError.
         """
         url = f"{self.base_url}/{path.lstrip('/')}"
-        kwargs.setdefault("timeout", self.timeout)
+        kwargs.setdefault("timeout", aiohttp.ClientTimeout(total=self.timeout))
 
         last_error: Optional[BaseException] = None
         delay = self.retry_delay

--- a/async_client.py
+++ b/async_client.py
@@ -172,11 +172,14 @@ class AsyncRestStore:
     async def exists(self, key: str) -> bool:
         """Check if an object exists (async)."""
         try:
-            resp = await self._make_request("HEAD", f"objects/{key}")
+            resp = await self._make_request("HEAD", f"objects/{key}", allow_404=True)
+            if resp.status == 404:
+                await resp.release()
+                return False
             await resp.release()
             return True
-        except (AsyncRestStoreError, KeyError):
-            return False
+        except:
+            raise
 
     async def delete(self, key: str) -> None:
         """Delete an object (async)."""

--- a/async_client.py
+++ b/async_client.py
@@ -1,0 +1,223 @@
+import asyncio
+from typing import AsyncIterator, Iterable, Optional
+
+import aiohttp
+from aiohttp import ClientError
+
+from storage.object import ObjectStore
+from storage.utils import UrlEncodingStore
+
+
+class AsyncRestStoreError(Exception):
+    """Base exception for async REST store errors"""
+    pass
+
+
+class AsyncRestStore(ObjectStore):
+    """
+    Async REST client implementation of ObjectStore interface.
+
+    Mirrors RestStore in client.py but uses aiohttp and async/await.
+    """
+
+    @classmethod
+    def create(cls, *args, **kwargs) -> ObjectStore:
+        """
+        Factory method to create a URL-encoding enabled async REST store.
+
+        Takes the same arguments as the AsyncRestStore constructor.
+        Returns an ObjectStore instance that handles URL-encoded keys.
+        """
+        base_store = cls(*args, **kwargs)
+        return UrlEncodingStore(base_store)
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        timeout: float = 30.0,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        session: Optional[aiohttp.ClientSession] = None,
+    ):
+        """
+        Initialize the async REST store client.
+
+        Args mirror RestStore in client.py.
+        """
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+
+        self._external_session = session is not None
+        self._session: Optional[aiohttp.ClientSession] = session
+
+    # --------------------------------------------------------------------- #
+    # Session / context management
+    # --------------------------------------------------------------------- #
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(total=self.timeout)
+            self._session = aiohttp.ClientSession(
+                timeout=timeout,
+                headers={"Authorization": f"Bearer {self.api_key}"},
+            )
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed and not self._external_session:
+            await self._session.close()
+
+    async def __aenter__(self) -> "AsyncRestStore":
+        await self._ensure_session()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
+
+    # --------------------------------------------------------------------- #
+    # Internal request helper with retries
+    # --------------------------------------------------------------------- #
+    async def _make_request(self, method: str, path: str, **kwargs) -> aiohttp.ClientResponse:
+        """
+        Make an HTTP request with retry logic (async).
+
+        Mirrors RestStore._make_request but uses aiohttp and asyncio.sleep.
+        """
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        kwargs.setdefault("timeout", self.timeout)
+
+        last_error: Optional[BaseException] = None
+        delay = self.retry_delay
+
+        session = await self._ensure_session()
+
+        for attempt in range(self.max_retries):
+            try:
+                resp = await session.request(method, url, **kwargs)
+
+                # Check for rate limiting
+                if resp.status == 429:
+                    retry_after = resp.headers.get("Retry-After")
+                    try:
+                        retry_after_val = int(retry_after) if retry_after is not None else delay
+                    except ValueError:
+                        retry_after_val = delay
+                    await resp.release()
+                    await asyncio.sleep(retry_after_val)
+                    continue
+
+                # Handle error status codes
+                if resp.status >= 400:
+                    # Try to read JSON error, but don't fail if it isn't JSON
+                    try:
+                        data = await resp.json()
+                        error_data = data.get("error", {})
+                        message = error_data.get("message", "Unknown error")
+                    except Exception:
+                        text = await resp.text()
+                        message = f"{resp.status} error: {text}"
+                    await resp.release()
+                    raise AsyncRestStoreError(f"HTTP {resp.status}: {message}")
+
+                return resp
+
+            except (ClientError, asyncio.TimeoutError) as e:
+                last_error = e
+                if attempt < self.max_retries - 1:
+                    await asyncio.sleep(delay)
+                    delay *= 2
+                    continue
+                raise AsyncRestStoreError(
+                    f"Request failed after {self.max_retries} attempts"
+                ) from e
+
+        if last_error:
+            raise AsyncRestStoreError(
+                f"Request failed after {self.max_retries} attempts"
+            ) from last_error
+
+        raise AsyncRestStoreError("Unexpected error in request retry loop")
+
+    # --------------------------------------------------------------------- #
+    # Public async API (async analogs of RestStore methods)
+    # --------------------------------------------------------------------- #
+    async def put(self, key: str, data: bytes) -> None:
+        """Store an object (async)."""
+        try:
+            resp = await self._make_request("PUT", f"objects/{key}", data=data)
+            await resp.release()
+        except AsyncRestStoreError as e:
+            raise KeyError(f"Failed to store object {key}: {str(e)}")
+
+    async def get(self, key: str) -> bytes:
+        """Retrieve an object (async)."""
+        try:
+            resp = await self._make_request("GET", f"objects/{key}")
+            async with resp:
+                return await resp.read()
+        except AsyncRestStoreError as e:
+            raise KeyError(f"Failed to retrieve object {key}: {str(e)}")
+
+    async def exists(self, key: str) -> bool:
+        """Check if an object exists (async)."""
+        try:
+            resp = await self._make_request("HEAD", f"objects/{key}")
+            await resp.release()
+            return True
+        except (AsyncRestStoreError, KeyError):
+            return False
+
+    async def delete(self, key: str) -> None:
+        """Delete an object (async)."""
+        try:
+            resp = await self._make_request("DELETE", f"objects/{key}")
+            await resp.release()
+        except AsyncRestStoreError as e:
+            raise KeyError(f"Failed to delete object {key}: {str(e)}")
+
+    async def keys(self) -> AsyncIterator[str]:
+        """List all object keys with pagination (async iterator)."""
+        cursor: Optional[str] = None
+
+        while True:
+            try:
+                params = {"limit": 100}
+                if cursor:
+                    params["cursor"] = cursor
+
+                resp = await self._make_request("GET", "objects", params=params)
+                async with resp:
+                    data = await resp.json()
+
+                for key in data.get("keys", []):
+                    yield key
+
+                if not data.get("has_more"):
+                    break
+
+                cursor = data.get("next_cursor")
+                if not cursor:
+                    break
+
+            except AsyncRestStoreError as e:
+                # Keep NotImplementedError to mirror sync behavior
+                raise NotImplementedError(f"Failed to list keys: {str(e)}")
+
+# Example usage (for reference only; do not run on import):
+# async def main():
+#     async with AsyncRestStore(
+#         base_url="https://api.objectstore.example/v1",
+#         api_key="your-api-key",
+#     ) as store:
+#         await store.put("example-key", b"Hello, Async World!")
+#         data = await store.get("example-key")
+#         print(data.decode())
+#
+#         async for key in store.keys():
+#             print(key)
+#
+# if __name__ == "__main__":
+#     asyncio.run(main())

--- a/async_test.py
+++ b/async_test.py
@@ -1,0 +1,110 @@
+import os
+import pytest
+import pytest_asyncio
+
+# Configure pytest-asyncio to use module-level event loop for async fixtures
+pytestmark = pytest.mark.asyncio
+pytest_asyncio.plugin.asyncio_default_fixture_loop_scope = "module"
+
+from async_client import AsyncRestStore
+
+@pytest_asyncio.fixture
+async def async_store():
+    """Create a test AsyncRestStore instance"""
+    store = AsyncRestStore.create(
+        base_url='http://localhost:8000',
+        api_key=os.environ.get('TEST_API_KEY', 'test_api_key'),
+    )
+    try:
+        yield store
+    finally:
+        # Clean up any test data
+        keys = []
+        async for key in store.keys():
+            keys.append(key)
+        for key in keys:
+            if key.startswith('test_'):
+                try:
+                    await store.delete(key)
+                except KeyError:
+                    pass
+        if isinstance(store, AsyncRestStore):
+            await store.close()
+
+@pytest.mark.asyncio
+async def test_crud_operations(async_store):
+    """Test basic CRUD operations (async)"""
+    key = 'test_object'
+    data = b'Hello, World!'
+
+    # Test put and exists
+    assert not await async_store.exists(key)
+    await async_store.put(key, data)
+    assert await async_store.exists(key)
+
+    # Test get
+    retrieved = await async_store.get(key)
+    assert retrieved == data
+
+    # Test delete
+    await async_store.delete(key)
+    assert not await async_store.exists(key)
+    with pytest.raises(KeyError):
+        await async_store.get(key)
+
+@pytest.mark.asyncio
+async def test_list_keys(async_store):
+    """Test listing keys (async)"""
+    # Create some test objects
+    test_data = {
+        'test_1': b'data1',
+        'test_2': b'data2',
+        'test_3': b'data3',
+    }
+
+    for key, data in test_data.items():
+        await async_store.put(key, data)
+
+    # Get all keys and filter test keys
+    keys = set()
+    async for k in async_store.keys():
+        if k.startswith('test_'):
+            keys.add(k)
+    assert keys == set(test_data.keys())
+
+@pytest.mark.asyncio
+async def test_nonexistent_key(async_store):
+    """Test operations with nonexistent keys (async)"""
+    key = 'test_nonexistent'
+
+    assert not await async_store.exists(key)
+
+    with pytest.raises(KeyError):
+        await async_store.get(key)
+
+    with pytest.raises(KeyError):
+        await async_store.delete(key)
+
+@pytest.mark.asyncio
+async def test_binary_data(async_store):
+    """Test storing and retrieving binary data (async)"""
+    key = 'test_binary'
+    data = bytes([0, 1, 2, 3, 255, 254, 253, 252])
+
+    await async_store.put(key, data)
+    retrieved = await async_store.get(key)
+    assert retrieved == data
+
+@pytest.mark.asyncio
+async def test_special_characters_in_keys(async_store):
+    """Test keys with special characters (async)"""
+    key = 'test_special/characters !@#$%^&*()_+'
+    data = b'Special characters'
+
+    await async_store.put(key, data)
+    retrieved = await async_store.get(key)
+    assert retrieved == data
+
+if __name__ == '__main__':
+    # Allow running directly with pytest
+    pytest.main([__file__])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
-git+https://github.com/WHOIGit/amplify-storage-utils
+git+https://github.com/WHOIGit/amplify-storage-utils@v1.2.0
 requests
 uvicorn
 pytest

--- a/test.py
+++ b/test.py
@@ -1,4 +1,6 @@
+import os
 import pytest
+
 from client import RestStore
 
 @pytest.fixture
@@ -6,7 +8,7 @@ def store():
     """Create a test RestStore instance"""
     store = RestStore.create(
         base_url='http://localhost:8000',
-        api_key='test-key'
+        api_key=os.environ.get('TEST_API_KEY', 'test_api_key')
     )
     yield store
     # Clean up any test data


### PR DESCRIPTION
This pull request introduces asynchronous support for object storage operations and adds comprehensive tests for the new async client. The main changes include implementing an async in-memory store, refactoring API endpoints to use async methods, adding an `AsyncRestStore` client for RESTful async operations, and providing a suite of async tests. These updates allow for non-blocking object CRUD operations and set the foundation for scalable async usage.

Async storage and API changes:
* Added `AsyncDictStore` class in `app.py` for in-memory async object storage and refactored the FastAPI lifespan to use it instead of the synchronous `DictStore`.
* Updated all object CRUD endpoints in `app.py` (`put_object`, `get_object`, `head_object`, `delete_object`, `list_objects`) to use `await` for store operations, making them fully asynchronous. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L78-R104) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L98-R124) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L117-R143) [[4]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L132-R158) [[5]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L151-R177)

Async REST client implementation:
* Added new `async_client.py` file with the `AsyncRestStore` class, providing async methods for put, get, exists, delete, and keys, including retry logic and pagination.

Testing improvements:
* Added `async_test.py` with pytest-asyncio tests for async CRUD operations, key listing, binary data, and special character support in keys, ensuring robust async client functionality.
* Updated `test.py` to use environment variable for API key, supporting more flexible test configuration.